### PR TITLE
update defaults to use native tmpfs /tmp

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -579,7 +579,7 @@ deb13cis_debug_mount_data: false
 # If set to `true`, rule will be implemented using the `tmp.mount` systemd-service,
 # otherwise fstab configuration will be used.
 # These /tmp settings will include nosuid,nodev,noexec to conform to CIS standards.
-deb13cis_tmp_svc: false
+deb13cis_tmp_svc: true
 
 ## Controls 1.3.1.x - apparmor
 # AppArmor security policies define what system resources applications can access and their privileges.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,6 +14,7 @@
   listen: "Remount /tmp"
 
 - name: "Remounting /tmp"
+  when: deb13cis_tmp_svc is falsy
   vars:
     mount_point: '/tmp'
   ansible.posix.mount:
@@ -22,11 +23,10 @@
   listen: "Remount /tmp"
 
 - name: "Remounting /tmp systemd"
-  vars:
-    mount_point: '/tmp'
+  when: deb13cis_tmp_svc is truthy
   ansible.builtin.systemd:
     name: tmp.mount
-    state: restarted
+    state: reloaded
     daemon_reload: true
   listen: "Remount /tmp"
 


### PR DESCRIPTION
As mentioned in the Debian 13 changelog, /tmp is now by default a /tmpfs so it
seems sensible to follow this lead.

https://www.debian.org/releases/stable/release-notes/issues.en.html#the-temporary-files-directory-tmp-is-now-stored-in-a-tmpfs

Signed-off-by: seven beep ebn@entreparentheses.xyz