### PR TITLE
Add audit rules for systemd-networkd

### DIFF
--- a/tasks/section_6/cis_6.2.3.x.yml
+++ b/tasks/section_6/cis_6.2.3.x.yml
@@ -105,6 +105,11 @@
   block:
     - name: "6.2.3.8 | PATCH | Ensure events that modify the system's network environment are collected"
       ansible.builtin.stat:
+        path: /etc/network/interfaces
+      register: discovered_interfaces_stat
+
+    - name: "6.2.3.8 | PATCH | Ensure events that modify the system's network environment are collected"
+      ansible.builtin.stat:
         path: /etc/network/interfaces.d
       register: discovered_interfaces_d_stat
 

--- a/templates/etc/audit/rules.d/99_auditd.rules.j2
+++ b/templates/etc/audit/rules.d/99_auditd.rules.j2
@@ -47,6 +47,14 @@
 ## The following line is commented out as path not present when checked
 # -a always,exit -F arch=b64 -S all -F dir=/etc/netplan -F perm=wa -k system-locale
 {% endif %}
+{% if 'systemd-networkd' in ansible_facts.packages %}
+-a always,exit -F arch=b64 -S all -F path=/etc/systemd/networkd.conf -F perm=wa -k system-locale
+-a always,exit -F arch=b64 -S all -F dir=/etc/systemd/network -F perm=wa -k system-locale
+{% else %}
+## The following line is commented out as systemd-networkd was nost installed when checked
+# -a always,exit -F arch=b64 -S all -F path=/etc/systemd/networkd.conf -F perm=wa -k system-locale
+# -a always,exit -F arch=b64 -S all -F dir=/etc/systemd/network -F perm=wa -k system-locale
+{% endif %}
 {% endif %}
 {% if deb13cis_rule_6_2_3_9 %}
 {% if discovered_network_manager_stat.stat.exists %}

--- a/templates/etc/audit/rules.d/99_auditd.rules.j2
+++ b/templates/etc/audit/rules.d/99_auditd.rules.j2
@@ -34,7 +34,12 @@
 -a always,exit -F arch=b64 -S all -F path=/etc/hostname -F perm=wa -k system-locale
 {% endif %}
 {% if deb13cis_rule_6_2_3_8 %}
+{% if discovered_interfaces_stat.stat.exists %}
 -a always,exit -F arch=b64 -S all -F path=/etc/network/interfaces -F perm=wa -k system-locale
+{% else %}
+## The following line is commented out as path not present when checked
+# -a always,exit -F arch=b64 -S all -F path=/etc/network/interfaces -F perm=wa -k system-locale
+{% endif %}
 {% if discovered_interfaces_d_stat.stat.exists %}
 -a always,exit -F arch=b64 -S all -F dir=/etc/network/interfaces.d -F perm=wa -k system-locale
 {% else %}


### PR DESCRIPTION
You may want to also check systemd-networkd configurations files, especially
since it is used by default on cloud images.

Signed-off-by: seven beep <ebn@entreparentheses.xyz>