### PR TITLE
fix: sync remediation fixes from private

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,6 +3,5 @@
 quiet: true
 skip_list:
   - 'package-latest'
-  - 'risky-shell-pipe'
 use_default_rules: true
 verbosity: 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     name: Detect Secrets test
 
 - repo: https://github.com/gitleaks/gitleaks
-  rev: v8.30.0
+  rev: v8.30.1
   hooks:
   - id: gitleaks
     name: Run Gitleaks test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changes to DEB13CIS
 
+## Based on CIS v1.0.0 - Branch sept26_update
+
+- sept26_update branch
+  - 7.1.13 find used -perm \( ... or ... \); find read \( as the mode and never returned a
+    file, so the SUID/SGID review passed vacuously. Now \( -perm -02000 -o -perm -04000 \)
+  - 1.1.1.6 blacklisted overlayfs, which has not existed since the 3.x kernels. Now overlay,
+    host-verified: modprobe -n -v overlay went from loading overlay.ko.xz to install /bin/true
+  - 1.2.1.2 and 1.3.1.4 when: expressions were invalid Jinja (unquoted path, and not used as a
+    binary operator) - both now quoted comparisons
+  - prelim apt.conf.d find used patterns: .* as a glob, matching only dotfiles, so 1.2.1.2
+    processed nothing. Added use_regex: true - host-verified 0 of 6 files matched before, 6 after
+  - 3.2.1-3.2.6 modprobe tasks looped two lines against one fixed regexp, so the second item
+    overwrote the first. Each item now carries its own regexp
+  - 3.2.x install regexps were single-quoted, so \\s stayed literal and never matched
+  - 3.1.2 wrote "install <mod> true" with a regexp naming "true"; now /bin/true and the module
+  - 6.1.1.2.2 notified Restart journald, restarting the wrong service; now
+    Restart systemd_journal_upload, which was previously unreachable
+  - 7.2.7 warning referenced discovered_user_username_check, which is defined nowhere
+  - removed a verbatim duplicate 3.2.3 dccp block
+  - ansible_facts dot notation converted to bracket notation, 37 occurrences across 17 files
+  - check_prereqs.yml when: reflowed to double quotes, the bracket form collides with a single-quoted scalar
+  - deb13cis_shell_executable added to vars/main.yml, the role had no shell executable var
+  - set -o pipefail and args executable applied to all 64 shell tasks
+  - 4 folded '>' shell scalars in prelim.yml converted to literal '|', pipefail cannot work in a folded block
+  - 34 hardcoded executable /bin/bash replaced with the role var
+  - risky-shell-pipe removed from the .ansible-lint skip_list, the role now passes with it enabled
+  - fixed the collection of audit privileged commands
+  - 6.2.3.10 registered discovered_privileged_commands but the template reads discovered_privilege_processes, so no rules were written
+  - Audit: 6.2.3.10 placeholder replaced with conf and running checks
+
 ## Based on CIS v1.0.0 - Branch align_1.0.0
 
 - 7.2.9 set default ACLs on home directories but never removed excessive permissions from the

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -149,7 +149,7 @@
   changed_when: true
 
 - name: Restart coredump
-  when: "'systemd-coredump' in ansible_facts.packages"
+  when: "'systemd-coredump' in ansible_facts['packages']"
   ansible.builtin.systemd:
     name: systemd-coredump.socket
     state: restarted

--- a/tasks/LE_audit_setup.yml
+++ b/tasks/LE_audit_setup.yml
@@ -3,12 +3,12 @@
 - name: Pre Audit Setup | Set audit package name
   block:
     - name: Pre Audit Setup | Set audit package name | 64bit
-      when: ansible_facts.machine == "x86_64"
+      when: ansible_facts['machine'] == "x86_64"
       ansible.builtin.set_fact:
         audit_pkg_arch_name: AMD64
 
     - name: Pre Audit Setup | Set audit package name | ARM64
-      when: (ansible_facts.machine == "arm64" or ansible_facts.machine == "aarch64")
+      when: (ansible_facts['machine'] == "arm64" or ansible_facts['machine'] == "aarch64")
       ansible.builtin.set_fact:
         audit_pkg_arch_name: ARM64
 

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -4,21 +4,29 @@
 # we need to update the auditd rules depending on the architecture of the system.
 # This task passed the syscalls table to the auditd template and updates the auditd rules
 - name: "POST | AUDITD | Set supported_syscalls variable"
-  ansible.builtin.shell: ausyscall --dump |  awk  '{print $2}'
+  ansible.builtin.shell: |
+    set -o pipefail
+    ausyscall --dump |  awk  '{print $2}'
+  args:
+    executable: "{{ deb13cis_shell_executable }}"
   changed_when: false
   failed_when: discovered_auditd_syscalls.rc not in [ 0, 1 ]
   register: discovered_auditd_syscalls
 
 - name: "POST | AUDITD | Ensure use of privileged commands is collected"
   ansible.builtin.shell: |
-    {%- set egrep_exclude = "(asdfmnop|{{ deb13cis_priv_command_excluded_mounts | join('|') }})" -%}
-    for i in $(df | grep '^/dev' | grep -Ev '{{ egrep_exclude }}' | awk '{ print $NF }'); do
+    set -o pipefail
+    for i in $(df | grep '^/dev' | grep -Ev '(asdfmnop{% if deb13cis_priv_command_excluded_mounts | length > 0 %}|{{ exclude_options }}{% endif %})' | awk '{ print $NF }'); do
       find $i -xdev -type f -perm /6000 2>/dev/null;
     done
+  args:
+    executable: "{{ deb13cis_shell_executable }}"
   changed_when: false
-  failed_when: false
+  failed_when: discovered_privilege_processes.rc not in [0, 1]
   check_mode: false
-  register: discovered_privileged_commands
+  register: discovered_privilege_processes
+  vars:
+    exclude_options: "{{ deb13cis_priv_command_excluded_mounts | join('|') }}"
 
 - name: "POST | AUDITD | Apply auditd template for section 6.2.4.x"
   when: update_audit_template

--- a/tasks/check_prereqs.yml
+++ b/tasks/check_prereqs.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "PREREQ | Ensure python3-apt is installed for package management"
-  when: '"python3-apt" not in ansible_facts.packages'
+  when: "'python3-apt' not in ansible_facts['packages']"
   ansible.builtin.package:
     name: python3-apt
     state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,9 +5,9 @@
   when: os_check
   tags: always
   ansible.builtin.assert:
-    that: ansible_facts.distribution == 'Debian' and ansible_facts.distribution_major_version is version_compare('13', '==')
-    fail_msg: "This role can only be run against Supported OSs. {{ ansible_facts.distribution }} {{ ansible_facts.distribution_major_version }} is not supported."
-    success_msg: "This role is running against a supported OS {{ ansible_facts.distribution }} {{ ansible_facts.distribution_major_version }}"
+    that: ansible_facts['distribution'] == 'Debian' and ansible_facts['distribution_major_version'] is version_compare('13', '==')
+    fail_msg: "This role can only be run against Supported OSs. {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_major_version'] }} is not supported."
+    success_msg: "This role is running against a supported OS {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_major_version'] }}"
 
 - name: "Check ansible version"
   tags: always
@@ -17,7 +17,7 @@
     success_msg: "This role is running a supported version of ansible {{ ansible_version.full }} >= {{ min_ansible_version }}"
 
 - name: "Setup rules if container"
-  when: ansible_connection in ['docker', 'community.docker.docker'] or ansible_facts.virtualization_type in ["docker", "lxc", "openvz", "podman", "container"]
+  when: ansible_connection in ['docker', 'community.docker.docker'] or ansible_facts['virtualization_type'] in ["docker", "lxc", "openvz", "podman", "container"]
   tags:
     - container_discovery
     - always
@@ -56,9 +56,11 @@
     sudo_password_rule: deb13cis_rule_5_2_4  # pragma: allowlist secret
   block:
     - name: "Check password set for {{ ansible_env.SUDO_USER }} | password state"  # noqa name[template]
-      ansible.builtin.shell: "(grep {{ ansible_env.SUDO_USER }} /etc/shadow || echo 'not found:not found') | awk -F: '{print $2}'"
+      ansible.builtin.shell: |
+        set -o pipefail
+        (grep {{ ansible_env.SUDO_USER }} /etc/shadow || echo 'not found:not found') | awk -F: '{print $2}'
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       check_mode: false
@@ -97,9 +99,11 @@
     - rule_5.4.2.4
   block:
     - name: "Ensure root password is set"
-      ansible.builtin.shell: passwd -S root | grep 'root P'
+      ansible.builtin.shell: |
+        set -o pipefail
+        passwd -S root | grep 'root P'
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       register: prelim_check_root_passwd_set
@@ -118,7 +122,7 @@
 - name: "Include OS specific variables"
   tags: always
   ansible.builtin.include_vars:
-    file: "{{ ansible_facts.distribution }}.yml"
+    file: "{{ ansible_facts['distribution'] }}.yml"
 
 - name: "Include preliminary steps"
   tags:

--- a/tasks/post.yml
+++ b/tasks/post.yml
@@ -30,7 +30,7 @@
   when:
     - deb13cis_sysctl_update
     - not system_is_container
-    - "'procps' in ansible_facts.packages"
+    - "'procps' in ansible_facts['packages']"
   tags: always
   ansible.builtin.template:
     src: "etc/sysctl.d/{{ item }}.j2"

--- a/tasks/post_remediation_audit.yml
+++ b/tasks/post_remediation_audit.yml
@@ -1,7 +1,11 @@
 ---
 
 - name: Post Audit | Run post_remediation {{ benchmark }} audit # noqa name[template]
-  ansible.builtin.shell: "umask 0022 && {{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -f {{ audit_format }} -m {{ audit_max_concurrent }} -o {{ post_audit_outfile }} -g \"{{ group_names }}\""  # noqa yaml[line-length]
+  ansible.builtin.shell: |  # noqa yaml[line-length]
+    set -o pipefail
+    umask 0022 && {{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -f {{ audit_format }} -m {{ audit_max_concurrent }} -o {{ post_audit_outfile }} -g "{{ group_names }}"
+  args:
+    executable: "{{ deb13cis_shell_executable }}"
   changed_when: true
   environment:
     AUDIT_BIN: "{{ audit_bin }}"
@@ -12,7 +16,11 @@
   when: audit_format == "json"
   block:
     - name: Post Audit | Capture audit data if json format
-      ansible.builtin.shell: grep -E '"summary-line.*Count:.*Failed' "{{ post_audit_outfile }}" | cut -d'"' -f4
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -E '"summary-line.*Count:.*Failed' "{{ post_audit_outfile }}" | cut -d'"' -f4
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       register: post_audit_summary_json
 
@@ -24,7 +32,11 @@
   when: audit_format == "documentation"
   block:
     - name: Post Audit | Capture audit data if documentation format
-      ansible.builtin.shell: tail -2 "{{ post_audit_outfile }}"  | tac | tr '\n' ' '
+      ansible.builtin.shell: |
+        set -o pipefail
+        tail -2 "{{ post_audit_outfile }}"  | tac | tr '\n' ' '
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       register: post_audit_summary_documentation
 

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -73,7 +73,11 @@
     mode: 'go-rwx'
 
 - name: Pre Audit | Run pre_remediation audit {{ benchmark }} # noqa name[template]
-  ansible.builtin.shell: "umask 0022 && {{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -f {{ audit_format }} -m {{ audit_max_concurrent }} -o {{ pre_audit_outfile }} -g \"{{ group_names }}\""  # noqa yaml[line-length]
+  ansible.builtin.shell: |  # noqa yaml[line-length]
+    set -o pipefail
+    umask 0022 && {{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -f {{ audit_format }} -m {{ audit_max_concurrent }} -o {{ pre_audit_outfile }} -g "{{ group_names }}"
+  args:
+    executable: "{{ deb13cis_shell_executable }}"
   changed_when: true
   environment:
     AUDIT_BIN: "{{ audit_bin }}"
@@ -84,7 +88,11 @@
   when: audit_format == "json"
   block:
     - name: Pre Audit | Capture audit data if json format
-      ansible.builtin.shell: grep -E '\"summary-line.*Count:.*Failed' "{{ pre_audit_outfile }}" | cut -d'"' -f4
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -E '\"summary-line.*Count:.*Failed' "{{ pre_audit_outfile }}" | cut -d'"' -f4
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       register: pre_audit_summary_json
 
@@ -96,7 +104,11 @@
   when: audit_format == "documentation"
   block:
     - name: Pre Audit | Capture audit data if documentation format
-      ansible.builtin.shell: tail -2 "{{ pre_audit_outfile }}"  | tac | tr '\n' ' '
+      ansible.builtin.shell: |
+        set -o pipefail
+        tail -2 "{{ pre_audit_outfile }}"  | tac | tr '\n' ' '
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       register: pre_audit_summary_documentation
 

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -17,9 +17,11 @@
 - name: "PRELIM | AUDIT | Register if snap being used"
   when: deb13cis_rule_1_1_1_7
   tags: always
-  ansible.builtin.shell: df -h | grep -wc "/snap"
+  ansible.builtin.shell: |
+    set -o pipefail
+    df -h | grep -wc "/snap"
   args:
-    executable: /bin/bash
+    executable: "{{ deb13cis_shell_executable }}"
   changed_when: false
   failed_when: prelim_snap_pkg_mgr.rc not in [ 0, 1 ]
   register: prelim_snap_pkg_mgr
@@ -27,41 +29,55 @@
 - name: "PRELIM | AUDIT | Register if squashfs is built into the kernel"
   when: deb13cis_rule_1_1_1_7
   tags: always
-  ansible.builtin.shell: cat /lib/modules/$(uname -r)/modules.builtin | grep -c "squashfs"
+  ansible.builtin.shell: |
+    set -o pipefail
+    cat /lib/modules/$(uname -r)/modules.builtin | grep -c "squashfs"
   args:
-    executable: /bin/bash
+    executable: "{{ deb13cis_shell_executable }}"
   changed_when: false
   failed_when: prelim_squashfs_builtin.rc not in [ 0, 1 ]
   register: prelim_squashfs_builtin
 
 - name: "PRELIM | AUDIT | Interactive Users"
   tags: always
-  ansible.builtin.shell: >
+  ansible.builtin.shell: |
+    set -o pipefail
     grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false" && $7 != "/dev/null") { print $1 }'
+  args:
+    executable: "{{ deb13cis_shell_executable }}"
   changed_when: false
   check_mode: false
   register: prelim_interactive_usernames
 
 - name: "PRELIM | AUDIT | Interactive User accounts home directories"
   tags: always
-  ansible.builtin.shell: >
+  ansible.builtin.shell: |
+    set -o pipefail
     grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false") { print $6 }'
+  args:
+    executable: "{{ deb13cis_shell_executable }}"
   changed_when: false
   check_mode: false
   register: prelim_interactive_users_home
 
 - name: "PRELIM | AUDIT | Interactive UIDs"
   tags: always
-  ansible.builtin.shell: >
+  ansible.builtin.shell: |
+    set -o pipefail
     grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false") { print $3 }'
+  args:
+    executable: "{{ deb13cis_shell_executable }}"
   changed_when: false
   check_mode: false
   register: prelim_interactive_uids
 
 - name: "PRELIM | AUDIT | Interactive Users | Gather username, uid and home"
   tags: always
-  ansible.builtin.shell: >
+  ansible.builtin.shell: |
+    set -o pipefail
     grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false" && $7 != "/dev/null") { print $1":"$3":"$6 }'
+  args:
+    executable: "{{ deb13cis_shell_executable }}"
   changed_when: false
   check_mode: false
   register: prelim_interactive_users_raw
@@ -86,16 +102,17 @@
 - name: PRELIM | AUDIT | Section 1.1 | Create list of mount points
   tags: always
   ansible.builtin.set_fact:
-    prelim_mount_names: "{{ ansible_facts.mounts | map(attribute='mount') | list }}"
+    prelim_mount_names: "{{ ansible_facts['mounts'] | map(attribute='mount') | list }}"
 
 - name: PRELIM | AUDIT | Section 1.1 | Retrieve mount options
   tags: always
   block:
     - name: PRELIM | AUDIT | Section 1.1 | Retrieve mount options - call mount # noqa command-instead-of-module
       ansible.builtin.shell: |
+        set -o pipefail
         mount | awk '{print $1, $3, $5, $6}'
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       check_mode: false
       register: prelim_mount_output
@@ -125,6 +142,7 @@
   ansible.builtin.find:
     path: /etc/apt/apt.conf.d/
     patterns: .*
+    use_regex: true
   register: prelim_apt_conf_files
 
 - name: "PRELIM | AUDIT | Set facts based on boot type"
@@ -171,7 +189,11 @@
   tags: always
   block:
     - name: "PRELIM | AUDIT | Discover is wireless adapter on system"
-      ansible.builtin.shell: find /sys/class/net/*/ -type d -name wireless
+      ansible.builtin.shell: |
+        set -o pipefail
+        find /sys/class/net/*/ -type d -name wireless
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: prelim_wireless_adapters.rc not in [ 0, 1 ]
       register: prelim_wireless_adapters
@@ -179,11 +201,12 @@
     - name: "PRELIM | AUDIT | If wireless adapter present capture module"
       when: prelim_wireless_adapters.rc == 0
       ansible.builtin.shell: |
+        set -o pipefail
         for driverdir in $(find /sys/class/net/*/ -type d -name wireless | xargs -0 dirname);
           do basename "$(readlink -f "$driverdir"/device/driver/module)";
         done | sort -u
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       check_mode: false
       failed_when: prelim_wireless_modules.rc not in [ 0, 1 ]
@@ -193,7 +216,7 @@
 - name: "PRELIM | PATCH | SSH Config file is not exist"
   when:
     - deb13cis_sshd_config_file != '/etc/ssh/sshd_config'
-    - "'openssh-server' in ansible_facts.packages"
+    - "'openssh-server' in ansible_facts['packages']"
   tags:
     - ssh
     - level1_server
@@ -251,9 +274,11 @@
     - level1-server
     - level1-workstation
     - users
-  ansible.builtin.shell: "cat /etc/passwd | awk -F: '($3 == 0 && $1 != \"root\") {i++;print $1 } END {exit i}'"
+  ansible.builtin.shell: |
+    set -o pipefail
+    cat /etc/passwd | awk -F: '($3 == 0 && $1 != "root") {i++;print $1 } END {exit i}'
   args:
-    executable: /bin/bash
+    executable: "{{ deb13cis_shell_executable }}"
   changed_when: false
   check_mode: false
   register: prelim_uid_zero_accounts_except_root
@@ -299,9 +324,11 @@
       deb13cis_rule_6_2_4_3 or
       deb13cis_rule_6_2_4_4
   tags: always
-  ansible.builtin.shell: grep ^log_file /etc/audit/auditd.conf | awk '{ print $NF }'
+  ansible.builtin.shell: |
+    set -o pipefail
+    grep ^log_file /etc/audit/auditd.conf | awk '{ print $NF }'
   args:
-    executable: /bin/bash
+    executable: "{{ deb13cis_shell_executable }}"
   changed_when: false
   check_mode: false
   register: prelim_auditd_logfile
@@ -331,17 +358,21 @@
   tags: always
   block:
     - name: "PRELIM | AUDIT | Capture UID_MIN information from logins.def"
-      ansible.builtin.shell: grep -w "^UID_MIN" /etc/login.defs | awk '{print $NF}'
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -w "^UID_MIN" /etc/login.defs | awk '{print $NF}'
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       check_mode: false
       register: prelim_uid_min_id
 
     - name: "PRELIM | AUDIT | Capture UID_MAX information from logins.def"
-      ansible.builtin.shell: grep -w "^UID_MAX" /etc/login.defs | awk '{print $NF}'
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -w "^UID_MAX" /etc/login.defs | awk '{print $NF}'
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       check_mode: false
       register: prelim_uid_max_id
@@ -365,9 +396,11 @@
     - always
   block:
     - name: "Optional | AUDIT | Check if UAS kernel module is running"
-      ansible.builtin.shell: "lsmod | grep uas"
+      ansible.builtin.shell: |
+        set -o pipefail
+        lsmod | grep uas
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       ignore_errors: true

--- a/tasks/section_1/cis_1.1.1.x.yml
+++ b/tasks/section_1/cis_1.1.1.x.yml
@@ -179,23 +179,23 @@
     - name: "1.1.1.6 | PATCH | Ensure overlay kernel module is not available | Edit modprobe config"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/CIS.conf
-        regexp: "^(#)?install overlayfs(\\s|$)"
-        line: "install overlayfs /bin/true"
+        regexp: "^(#)?install overlay(\\s|$)"
+        line: "install overlay /bin/true"
         create: true
         mode: 'u-x,go-rwx'
 
     - name: "1.1.1.6 | PATCH | Ensure overlay kernel module is not available | blacklist"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/blacklist.conf
-        regexp: "^(#)?blacklist overlayfs(\\s|$)"
-        line: "blacklist overlayfs"
+        regexp: "^(#)?blacklist overlay(\\s|$)"
+        line: "blacklist overlay"
         create: true
         mode: 'u-x,go-rwx'
 
     - name: "1.1.1.6 | PATCH | Ensure overlay kernel module is not available | Disable overlayfs"
       when: not system_is_container
       community.general.modprobe:
-        name: overlayfs
+        name: overlay
         state: absent
 
 - name: "1.1.1.7 | PATCH | Ensure squashfs kernel module is not available"

--- a/tasks/section_1/cis_1.2.1.x.yml
+++ b/tasks/section_1/cis_1.2.1.x.yml
@@ -12,7 +12,11 @@
     warn_control_id: '1.1.2.1'
   block:
     - name: "1.2.1.1 | AUDIT | Ensure the source.list and .source files use the Signed-By option"
-      ansible.builtin.shell: grep -PRLs -- '^([^#\n\r]+)?\bSigned-By\b' /etc/apt/sources.list /etc/apt/sources.list.d/*.{list,sources}
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -PRLs -- '^([^#\n\r]+)?\bSigned-By\b' /etc/apt/sources.list /etc/apt/sources.list.d/*.{list,sources}
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_apt_signed_by_missing.rc not in [ 0, 1, 2 ]
       register: discovered_apt_signed_by_missing
@@ -37,7 +41,7 @@
     - NIST800-53R5_SI-2
   block:
     - name: "1.2.1.2 | AUDIT | Ensure weak dependencies are configured | change configs not expected"
-      when: "item.path != /etc/apt/apt.conf.d/60-no-weak-dependencies"
+      when: item.path != '/etc/apt/apt.conf.d/60-no-weak-dependencies'
       ansible.builtin.replace:
         path: "{{ item.path }}"
         regexp: ^APT::Install-(Recommends|Suggests) "1"

--- a/tasks/section_1/cis_1.3.1.x.yml
+++ b/tasks/section_1/cis_1.3.1.x.yml
@@ -52,22 +52,30 @@
       changed_when: false
 
     - name: "1.3.1.3 | PATCH | Ensure all AppArmor Profiles are enforcing | Get pre apply enforce count"
-      ansible.builtin.shell: apparmor_status |  grep "profiles are in enforce mode" | tr -d -c 0-9
+      ansible.builtin.shell: |
+        set -o pipefail
+        apparmor_status |  grep "profiles are in enforce mode" | tr -d -c 0-9
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       register: discovered_apparmor_pre_count
 
     - name: "1.3.1.3 | PATCH | Ensure all AppArmor Profiles are enforcing | Apply enforcing to /etc/apparmor.d profiles"
-      ansible.builtin.shell: aa-enforce /etc/apparmor.d/*
+      ansible.builtin.shell: |
+        set -o pipefail
+        aa-enforce /etc/apparmor.d/*
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
 
     - name: "1.3.1.3 | PATCH | Ensure all AppArmor Profiles are enforcing | Get post apply enforce count"
-      ansible.builtin.shell: apparmor_status |  grep "profiles are in enforce mode" | tr -d -c 0-9
+      ansible.builtin.shell: |
+        set -o pipefail
+        apparmor_status |  grep "profiles are in enforce mode" | tr -d -c 0-9
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       register: discovered_apparmor_post_count
@@ -100,7 +108,7 @@
       register: discovered_apparmor_sysctl
 
     - name: "1.3.1.4 | AUDIT | Ensure apparmor_restrict_unprivileged_unconfined is enabled | comment out files"
-      when: "item.path not /etc/sysctl.d/60-kernel_sysctl.conf"
+      when: item.path != '/etc/sysctl.d/60-kernel_sysctl.conf'
       ansible.builtin.replace:
         path: "{{ item.path }}"
         regexp: (apparmor_restrict_unprivileged_unconfined\s*=\s*\d)

--- a/tasks/section_1/cis_1.5.x.yml
+++ b/tasks/section_1/cis_1.5.x.yml
@@ -233,7 +233,7 @@
     - NIST800-53R5_CM-6
   block:
     - name: "1.5.6 | PATCH | Ensure prelink is not installed | Restore binaries if installed"
-      when: "'prelink' in ansible_facts.packages"
+      when: "'prelink' in ansible_facts['packages']"
       ansible.builtin.command: "prelink -ua"
       changed_when: true
 
@@ -253,7 +253,7 @@
     - rule_1.5.7
   block:
     - name: "1.5.7 | PATCH | Ensure Automatic Error Reporting is configured | disable if installed"
-      when: "'apport' in ansible_facts.packages"
+      when: "'apport' in ansible_facts['packages']"
       ansible.builtin.lineinfile:
         path: /etc/default/apport
         regexp: enabled\s*=\s*(?!0)\d

--- a/tasks/section_1/cis_1.7.x.yml
+++ b/tasks/section_1/cis_1.7.x.yml
@@ -5,7 +5,7 @@
     - deb13cis_rule_1_7_1
     - not deb13cis_desktop_required
     - deb13cis_disruption_high
-    - "'gdm3' in ansible_facts.packages"
+    - "'gdm3' in ansible_facts['packages']"
   tags:
     - level2-server
     - patch

--- a/tasks/section_2/cis_2.1.x.yml
+++ b/tasks/section_2/cis_2.1.x.yml
@@ -3,7 +3,7 @@
 - name: "2.1.1 | PATCH | Ensure autofs services are not in use"
   when:
     - deb13cis_rule_2_1_1
-    - "'autofs' in ansible_facts.packages"
+    - "'autofs' in ansible_facts['packages']"
   tags:
     - level1-server
     - level2-workstation
@@ -139,7 +139,7 @@
 
 - name: "2.1.5 | PATCH | Ensure dnsmasq services are not in use"
   when:
-    - "'dnsmasq' in ansible_facts.packages"
+    - "'dnsmasq' in ansible_facts['packages']"
     - deb13cis_rule_2_1_5
   tags:
     - level1-server
@@ -447,7 +447,7 @@
 
 - name: "2.1.14 | PATCH | Ensure samba file server services are not in use"
   when:
-    - "'samba' in ansible_facts.packages"
+    - "'samba' in ansible_facts['packages']"
     - deb13cis_rule_2_1_14
   tags:
     - level1-server
@@ -714,7 +714,7 @@
 - name: "2.1.22 | PATCH | Ensure mail transfer agents are configured for local-only mode"
   when:
     - not deb13cis_is_mail_server
-    - "'postfix' in ansible_facts.packages"
+    - "'postfix' in ansible_facts['packages']"
     - deb13cis_rule_2_1_22
   tags:
     - level1-server

--- a/tasks/section_2/cis_2.3.1.x.yml
+++ b/tasks/section_2/cis_2.3.1.x.yml
@@ -33,7 +33,7 @@
     - name: "2.3.1.1 | PATCH | Ensure a single time synchronization daemon is in use | mask service"
       when:
         - deb13cis_time_sync_tool != "systemd-timesyncd"
-        - "'systemd-timesyncd' in ansible_facts.packages"
+        - "'systemd-timesyncd' in ansible_facts['packages']"
       ansible.builtin.service:
         name: systemd-timesyncd
         masked: true

--- a/tasks/section_2/cis_2.3.2.x.yml
+++ b/tasks/section_2/cis_2.3.2.x.yml
@@ -47,7 +47,7 @@
         enabled: true
 
     - name: "2.3.2.2 | PATCH | Ensure systemd-timesyncd is enabled and running | disable other time sources | chrony"
-      when: "'chrony' in ansible_facts.packages"
+      when: "'chrony' in ansible_facts['packages']"
       ansible.builtin.systemd:
         name: chrony
         state: stopped
@@ -55,7 +55,7 @@
         masked: true
 
     - name: "2.3.2.2 | PATCH | Ensure systemd-timesyncd is enabled and running | disable other time sources | ntp"
-      when: "'ntp' in ansible_facts.packages"
+      when: "'ntp' in ansible_facts['packages']"
       ansible.builtin.systemd:
         name: ntp
         state: stopped

--- a/tasks/section_2/cis_2.3.3.x.yml
+++ b/tasks/section_2/cis_2.3.3.x.yml
@@ -60,7 +60,7 @@
         enabled: true
 
     - name: "2.3.3.3 | PATCH | Ensure chrony is enabled and running | disable other time sources | timesyncd"
-      when: "'systemd-timesyncd' in ansible_facts.packages"
+      when: "'systemd-timesyncd' in ansible_facts['packages']"
       ansible.builtin.systemd:
         name: systemd-timesyncd
         state: stopped
@@ -68,7 +68,7 @@
         masked: true
 
     - name: "2.3.3.3 | PATCH | Ensure chrony is enabled and running | disable other time sources | ntpd"
-      when: "'ntpd' in ansible_facts.packages"
+      when: "'ntpd' in ansible_facts['packages']"
       ansible.builtin.systemd:
         name: ntpd
         state: stopped

--- a/tasks/section_3/cis_3.1.x.yml
+++ b/tasks/section_3/cis_3.1.x.yml
@@ -41,8 +41,8 @@
     - name: "3.1.2 | PATCH | Ensure wireless interfaces are not available | Create modprobe.d file"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/{{ item }}.conf
-        regexp: '^(#)?install true(\\s|$)'
-        line: install {{ item }} true
+        regexp: "^(#)?install {{ item }}(\\s|$)"
+        line: "install {{ item }} /bin/true"
         mode: 'u-x,go-wx'
         create: true
       loop: "{{ prelim_wireless_modules.stdout_lines }}"

--- a/tasks/section_3/cis_3.2.x.yml
+++ b/tasks/section_3/cis_3.2.x.yml
@@ -14,13 +14,13 @@
     - name: "3.2.1 | PATCH | Ensure atm kernel module is not available | modprobe"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/atm.conf
-        regexp: '^(#)?install atm(\\s|$)'
-        line: "{{ item }}"
+        regexp: "{{ item.regexp }}"
+        line: "{{ item.line }}"
         create: true
         mode: 'u-x,go-wx'
       loop:
-        - install atm /bin/true
-        - blacklist atm
+        - { regexp: "^(#)?install atm(\\s|$)", line: "install atm /bin/true" }
+        - { regexp: "^(#)?blacklist atm(\\s|$)", line: "blacklist atm" }
 
     - name: "3.2.1 | PATCH | Ensure atm kernel module is not available | blacklist"
       ansible.builtin.lineinfile:
@@ -44,13 +44,13 @@
     - name: "3.2.2 | PATCH | Ensure can kernel module is not available | modprobe"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/can.conf
-        regexp: '^(#)?install can(\\s|$)'
-        line: "{{ item }}"
+        regexp: "{{ item.regexp }}"
+        line: "{{ item.line }}"
         create: true
         mode: 'u-x,go-wx'
       loop:
-        - install can /bin/true
-        - blacklist can
+        - { regexp: "^(#)?install can(\\s|$)", line: "install can /bin/true" }
+        - { regexp: "^(#)?blacklist can(\\s|$)", line: "blacklist can" }
 
     - name: "3.2.2 | PATCH | Ensure can kernel module is not available | blacklist"
       ansible.builtin.lineinfile:
@@ -74,43 +74,13 @@
     - name: "3.2.3 | PATCH | Ensure dccp kernel module is not available | modprobe"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/dccp.conf
-        regexp: '^(#)?install dccp(\\s|$)'
-        line: "{{ item }}"
+        regexp: "{{ item.regexp }}"
+        line: "{{ item.line }}"
         create: true
         mode: 'u-x,go-wx'
       loop:
-        - install dccp /bin/true
-        - blacklist dccp
-
-    - name: "3.2.3 | PATCH | Ensure dccp kernel module is not available | blacklist"
-      ansible.builtin.lineinfile:
-        path: /etc/modprobe.d/blacklist.conf
-        regexp: "^(#)?blacklist dccp(\\s|$)"
-        line: "blacklist dccp"
-        create: true
-        mode: 'u-x,go-rwx'
-
-- name: "3.2.3 | PATCH | Ensure dccp kernel module is not available"
-  when: deb13cis_rule_3_2_3
-  tags:
-    - level2-server
-    - level2-workstation
-    - patch
-    - rule_3.2.3
-    - dccp
-    - NIST800-53R5_CM-7
-    - NIST800-53R5_SI-4
-  block:
-    - name: "3.2.3 | PATCH | Ensure dccp kernel module is not available | modprobe"
-      ansible.builtin.lineinfile:
-        path: /etc/modprobe.d/dccp.conf
-        regexp: '^(#)?install dccp(\\s|$)'
-        line: "{{ item }}"
-        create: true
-        mode: 'u-x,go-wx'
-      loop:
-        - install dccp /bin/true
-        - blacklist dccp
+        - { regexp: "^(#)?install dccp(\\s|$)", line: "install dccp /bin/true" }
+        - { regexp: "^(#)?blacklist dccp(\\s|$)", line: "blacklist dccp" }
 
     - name: "3.2.3 | PATCH | Ensure dccp kernel module is not available | blacklist"
       ansible.builtin.lineinfile:
@@ -134,13 +104,13 @@
     - name: "3.2.4 | PATCH | Ensure rds kernel module is not available | modprobe"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/rds.conf
-        regexp: '^(#)?install rds(\\s|$)'
-        line: "{{ item }}"
+        regexp: "{{ item.regexp }}"
+        line: "{{ item.line }}"
         create: true
         mode: 'u-x,go-wx'
       loop:
-        - install rds /bin/true
-        - blacklist rds
+        - { regexp: "^(#)?install rds(\\s|$)", line: "install rds /bin/true" }
+        - { regexp: "^(#)?blacklist rds(\\s|$)", line: "blacklist rds" }
 
     - name: "3.2.4 | PATCH | Ensure rds kernel module is not available | blacklist"
       ansible.builtin.lineinfile:
@@ -164,13 +134,13 @@
     - name: "3.2.5 | PATCH | Ensure sctp kernel module is not available | modprobe"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/sctp.conf
-        regexp: '^(#)?install sctp(\\s|$)'
-        line: "{{ item }}"
+        regexp: "{{ item.regexp }}"
+        line: "{{ item.line }}"
         create: true
         mode: 'u-x,go-wx'
       loop:
-        - install sctp /bin/true
-        - blacklist sctp
+        - { regexp: "^(#)?install sctp(\\s|$)", line: "install sctp /bin/true" }
+        - { regexp: "^(#)?blacklist sctp(\\s|$)", line: "blacklist sctp" }
 
     - name: "3.2.5 | PATCH | Ensure sctp kernel module is not available | blacklist"
       ansible.builtin.lineinfile:
@@ -194,13 +164,13 @@
     - name: "3.2.6 | PATCH | Ensure tipc kernel module is not available | modprobe"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/tipc.conf
-        regexp: '^(#)?install tipc(\\s|$)'
-        line: "{{ item }}"
+        regexp: "{{ item.regexp }}"
+        line: "{{ item.line }}"
         create: true
         mode: 'u-x,go-wx'
       loop:
-        - install tipc /bin/true
-        - blacklist tipc
+        - { regexp: "^(#)?install tipc(\\s|$)", line: "install tipc /bin/true" }
+        - { regexp: "^(#)?blacklist tipc(\\s|$)", line: "blacklist tipc" }
 
     - name: "3.2.6 | PATCH | Ensure tipc kernel module is not available | blacklist"
       ansible.builtin.lineinfile:

--- a/tasks/section_5/cis_5.1.x.yml
+++ b/tasks/section_5/cis_5.1.x.yml
@@ -176,7 +176,11 @@
     warn_control_id: "5.1.6"
   block:
     - name: "5.1.6 | AUDIT | Ensure sshd Ciphers are configured | Check state"
-      ansible.builtin.shell: sshd -T | grep -Pi -- '^ciphers\h+\"?([^#\n\r]+,)?((3des|blowfish|cast128|aes(128|192|256))-cbc|arcfour(128|256)?|rijndael-cbc@lysator\.liu\.se)\b'
+      ansible.builtin.shell: |
+        set -o pipefail
+        sshd -T | grep -Pi -- '^ciphers\h+\"?([^#\n\r]+,)?((3des|blowfish|cast128|aes(128|192|256))-cbc|arcfour(128|256)?|rijndael-cbc@lysator\.liu\.se)\b'
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       register: discovered_loaded_ciphers
@@ -323,7 +327,7 @@
 - name: "5.1.13 | PATCH | Ensure sshd post-quantum cryptography key exchange algorithms are configured"
   when:
     - deb13cis_rule_5_1_13
-    - "(ansible_facts.packages['openssh-server'][0].version.split('.') | first ) is version_compare ('1:10', '>=')"
+    - "(ansible_facts['packages']['openssh-server'][0].version.split('.') | first ) is version_compare ('1:10', '>=')"
   tags:
     - level1-server
     - level1-workstation

--- a/tasks/section_5/cis_5.2.x.yml
+++ b/tasks/section_5/cis_5.2.x.yml
@@ -58,7 +58,11 @@
     - NIST800-53R5_AC-6
   block:
     - name: "5.2.4 | AUDIT | Ensure users must provide password for escalation | discover accts with NOPASSWD"
-      ansible.builtin.shell: grep -Ei '(nopasswd)' /etc/sudoers /etc/sudoers.d/* | cut -d':' -f1
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -Ei '(nopasswd)' /etc/sudoers /etc/sudoers.d/* | cut -d':' -f1
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       become: true
       changed_when: false
       failed_when: false
@@ -84,7 +88,11 @@
     - NIST800-53R5_AC-6
   block:
     - name: "5.2.5 | AUDIT | Ensure re-authentication for privilege escalation is not disabled globally"
-      ansible.builtin.shell: grep -Ei '(!authenticate)' /etc/sudoers /etc/sudoers.d/* | cut -d':' -f1
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -Ei '(!authenticate)' /etc/sudoers /etc/sudoers.d/* | cut -d':' -f1
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       become: true
       changed_when: false
       failed_when: false
@@ -110,7 +118,11 @@
     - NIST800-53R5_AC-6
   block:
     - name: "5.2.6 | AUDIT | Ensure sudo authentication timeout is configured correctly | Get files with timeout set"
-      ansible.builtin.shell: grep -is 'timestamp_timeout' /etc/sudoers /etc/sudoers.d/* | cut -d":" -f1 | uniq | sort
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -is 'timestamp_timeout' /etc/sudoers /etc/sudoers.d/* | cut -d":" -f1 | uniq | sort
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       register: discovered_sudo_timeout_files

--- a/tasks/section_5/cis_5.3.3.1.x.yml
+++ b/tasks/section_5/cis_5.3.3.1.x.yml
@@ -22,7 +22,11 @@
         mode: 'u-x,go-rwx'
 
     - name: "5.3.3.1.1 | AUDIT | Ensure password failed attempts lockout is configured | discover pam config with deny"
-      ansible.builtin.shell: grep -Pl -- '\bpam_faillock\.so\h+([^#\n\r]+\h+)?deny\b' /usr/share/pam-configs/*
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -Pl -- '\bpam_faillock\.so\h+([^#\n\r]+\h+)?deny\b' /usr/share/pam-configs/*
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_faillock_deny_files.rc not in [ 0, 1 ]
       register: discovered_faillock_deny_files
@@ -57,7 +61,11 @@
         mode: 'u-x,go-rwx'
 
     - name: "5.3.3.1.2 | AUDIT | Ensure password unlock time is configured | discover pam config with unlock_time"
-      ansible.builtin.shell: grep -Pl -- '\bpam_faillock\.so\h+([^#\n\r]+\h+)?unlock_time\b' /usr/share/pam-configs/*
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -Pl -- '\bpam_faillock\.so\h+([^#\n\r]+\h+)?unlock_time\b' /usr/share/pam-configs/*
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_faillock_unlock_files.rc not in [ 0, 1 ]
       register: discovered_faillock_unlock_files
@@ -92,9 +100,11 @@
         mode: 'u-x,go-rwx'
 
     - name: "5.3.3.1.3 | AUDIT | Ensure password failed attempts lockout includes root account | discover pam config with unlock_time"
-      ansible.builtin.shell: grep -Pl -- '\bpam_faillock\.so\h+([^#\n\r]+\h+)?(even_deny_root\b|root_unlock_time\s*=\s*\d+\b)' /usr/share/pam-configs/*
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -Pl -- '\bpam_faillock\.so\h+([^#\n\r]+\h+)?(even_deny_root\b|root_unlock_time\s*=\s*\d+\b)' /usr/share/pam-configs/*
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_faillock_rootlock_files.rc not in [ 0, 1 ]
       register: discovered_faillock_rootlock_files

--- a/tasks/section_5/cis_5.3.3.3.x.yml
+++ b/tasks/section_5/cis_5.3.3.3.x.yml
@@ -13,7 +13,11 @@
     - NIST800-53R5_IA-5
   block:
     - name: "5.3.3.3.1 | AUDIT | Ensure password history remember is configured | Check existing files"
-      ansible.builtin.shell: grep -Psi -- '^\s*password\s+[^#\n\r]+\s+pam_pwhistory\.so\s+([^#\n\r]+\s+)?remember=\d+\b' /etc/pam.d/common-password
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -Psi -- '^\s*password\s+[^#\n\r]+\s+pam_pwhistory\.so\s+([^#\n\r]+\s+)?remember=\d+\b' /etc/pam.d/common-password
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_pwhistory_remember.rc not in [0, 1]
       register: discovered_pwhistory_remember
@@ -40,7 +44,11 @@
     - NIST800-53R5_IA-5
   block:
     - name: "5.3.3.3.2 | AUDIT | Ensure password history is enforced for the root user | Check existing files"
-      ansible.builtin.shell: grep -Psi -- '^\s*password\s+[^#\n\r]+\s+pam_pwhistory\.so\s+([^#\n\r]+\s+)?enforce_for_root\b' /etc/pam.d/common-password
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -Psi -- '^\s*password\s+[^#\n\r]+\s+pam_pwhistory\.so\s+([^#\n\r]+\s+)?enforce_for_root\b' /etc/pam.d/common-password
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_pwhistory_enforce_for_root.rc not in [0, 1]
       register: discovered_pwhistory_enforce_for_root
@@ -67,7 +75,11 @@
     - NIST800-53R5_IA-5
   block:
     - name: "5.3.3.3.3 | AUDIT | Ensure pam_pwhistory includes use_authtok | Check existing files"
-      ansible.builtin.shell: grep -Psi -- '^\s*password\s+[^#\n\r]+\s+pam_pwhistory\.so\s+([^#\n\r]+\s+)?use_authtok\b' /etc/pam.d/common-password
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -Psi -- '^\s*password\s+[^#\n\r]+\s+pam_pwhistory\.so\s+([^#\n\r]+\s+)?use_authtok\b' /etc/pam.d/common-password
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_pwhistory_use_authtok.rc not in [0, 1]
       register: discovered_pwhistory_use_authtok

--- a/tasks/section_5/cis_5.3.3.4.x.yml
+++ b/tasks/section_5/cis_5.3.3.4.x.yml
@@ -13,7 +13,11 @@
     - NIST800-53R5_NA
   block:
     - name: "5.3.3.4.1 | PATCH | Ensure pam_unix does not include nullok | capture state"
-      ansible.builtin.shell: grep -E "pam_unix.so.*nullok" /etc/pam.d/common-* /usr/share/pam-configs/* | cut -d ':' -f1 | uniq
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -E "pam_unix.so.*nullok" /etc/pam.d/common-* /usr/share/pam-configs/* | cut -d ':' -f1 | uniq
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_pam_unix_nullok.rc not in [ 0, 1 ]
       register: discovered_pam_unix_nullok
@@ -38,9 +42,11 @@
     - NIST800-53R5_NA
   block:
     - name: "5.3.3.4.2 | AUDIT | Ensure pam_unix does not include remember | capture state"
-      ansible.builtin.shell: grep -E "pam_unix.so.*remember=" /etc/pam.d/common-* /usr/share/pam-configs/* | cut -d ':' -f1 | uniq
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -E "pam_unix.so.*remember=" /etc/pam.d/common-* /usr/share/pam-configs/* | cut -d ':' -f1 | uniq
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_pam_unix_remember.rc not in [ 0, 1 ]
       register: discovered_pam_unix_remember
@@ -65,9 +71,11 @@
     - NIST800-53R5_IA-5
   block:
     - name: "5.3.3.4.3 | AUDIT | Ensure pam_unix includes a strong password hashing algorithm | capture state"
-      ansible.builtin.shell: grep -E "pam_unix.so.*(md5|bigcrypt|sha256|blowfish|gost_yescrypt|sha512|yescrypt)" /etc/pam.d/common-password /usr/share/pam-configs/* | cut -d ':' -f1 | uniq
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -E "pam_unix.so.*(md5|bigcrypt|sha256|blowfish|gost_yescrypt|sha512|yescrypt)" /etc/pam.d/common-password /usr/share/pam-configs/* | cut -d ':' -f1 | uniq
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_pam_unix_pwhash.rc not in [ 0, 1 ]
       register: discovered_pam_unix_pwhash
@@ -92,7 +100,11 @@
     - NIST800-53R5_IA-5
   block:
     - name: "5.3.3.4.4 | PATCH | Ensure pam_unix includes use_authtok | capture state"
-      ansible.builtin.shell: grep -PH -- '^\h*password\h+([^#\n\r]+)\h+pam_unix\.so\h+([^#\n\r]+\h+)?use_authtok\b' /etc/pam.d/common-password
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -PH -- '^\h*password\h+([^#\n\r]+)\h+pam_unix\.so\h+([^#\n\r]+\h+)?use_authtok\b' /etc/pam.d/common-password
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_pam_unix_authtok.rc not in [ 0, 1 ]
       register: discovered_pam_unix_authtok

--- a/tasks/section_5/cis_5.4.1.x.yml
+++ b/tasks/section_5/cis_5.4.1.x.yml
@@ -24,9 +24,11 @@
         insertafter: '# Password aging controls'
 
     - name: "5.4.1.1 | AUDIT | Ensure password expiration is configured | Get existing users PASS_MAX_DAYS"
-      ansible.builtin.shell: "awk -F: '(/^[^:]+:[^!*]/ && ($5>{{ deb13cis_pass_max_days }} || $5<{{ deb13cis_pass_max_days }} || $5 == -1)){print $1}' /etc/shadow"
+      ansible.builtin.shell: |
+        set -o pipefail
+        awk -F: '(/^[^:]+:[^!*]/ && ($5>{{ deb13cis_pass_max_days }} || $5<{{ deb13cis_pass_max_days }} || $5 == -1)){print $1}' /etc/shadow
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       register: discovered_passwd_max_days
@@ -156,9 +158,11 @@
     - rule_5.4.1.5
   block:
     - name: "5.4.1.5 | AUDIT | Ensure inactive password lock is configured | Check current settings"
-      ansible.builtin.shell: useradd -D | grep INACTIVE={{ deb13cis_inactivelock_lock_days }} | cut -f2 -d=
+      ansible.builtin.shell: |
+        set -o pipefail
+        useradd -D | grep INACTIVE={{ deb13cis_inactivelock_lock_days }} | cut -f2 -d=
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       check_mode: false
@@ -195,16 +199,22 @@
     warn_control_id: '5.4.1.6'
   block:
     - name: "5.4.1.6 | AUDIT | Ensure all users last password change date is in the past | Get current date in Unix Time"
-      ansible.builtin.shell: echo $(($(date --utc --date "$1" +%s)/86400))
+      ansible.builtin.shell: |
+        set -o pipefail
+        echo $(($(date --utc --date "$1" +%s)/86400))
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       check_mode: false
       register: discovered_current_epoch
 
     - name: "5.4.1.6 | AUDIT | Ensure all users last password change date is in the past | Get list of users with last changed pw date in the future"
-      ansible.builtin.shell: "cat /etc/shadow | awk -F: '{if($3>{{ discovered_current_epoch.stdout }})print$1}'"
+      ansible.builtin.shell: |
+        set -o pipefail
+        cat /etc/shadow | awk -F: '{if($3>{{ discovered_current_epoch.stdout }})print$1}'
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       check_mode: false

--- a/tasks/section_5/cis_5.4.2.x.yml
+++ b/tasks/section_5/cis_5.4.2.x.yml
@@ -40,9 +40,11 @@
     - NIST800-53R5_IA-5
   block:
     - name: "5.4.2.2 | AUDIT | Ensure root is the only GID 0 account | Get members of gid 0"
-      ansible.builtin.shell: "awk -F: '($1 !~ /^(sync|shutdown|halt|operator)/ && $4==\"0\") {print $1}' /etc/passwd | grep -wv 'root'"
+      ansible.builtin.shell: |
+        set -o pipefail
+        awk -F: '($1 !~ /^(sync|shutdown|halt|operator)/ && $4=="0") {print $1}' /etc/passwd | grep -wv 'root'
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_gid0_members.rc not in [ 0, 1 ]
       register: discovered_gid0_members
@@ -73,9 +75,11 @@
     - NIST800-53R5_IA-5
   block:
     - name: "5.4.2.3 | AUDIT | Ensure group root is the only GID 0 group | Get groups with gid 0"
-      ansible.builtin.shell: "awk -F: '$3==\"0\"{print $1}' /etc/group | grep -vw 'root'"
+      ansible.builtin.shell: |
+        set -o pipefail
+        awk -F: '$3=="0"{print $1}' /etc/group | grep -vw 'root'
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_gid0_groups.rc not in [ 0, 1 ]
       register: discovered_gid0_groups
@@ -125,17 +129,21 @@
     - NIST800-53R5_IA-5
   block:
     - name: "5.4.2.5 | AUDIT | Ensure root path Integrity | Get root paths"
-      ansible.builtin.shell: sudo -Hiu root env | grep '^PATH' | cut -d= -f2
+      ansible.builtin.shell: |
+        set -o pipefail
+        sudo -Hiu root env | grep '^PATH' | cut -d= -f2
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       register: discovered_root_paths
 
     - name: "5.4.2.5 | AUDIT | Ensure root path Integrity | Get root paths"
       when: discovered_root_paths is defined
-      ansible.builtin.shell: sudo -Hiu root env | grep '^PATH' | cut -d= -f2 | tr ":" "\n"
+      ansible.builtin.shell: |
+        set -o pipefail
+        sudo -Hiu root env | grep '^PATH' | cut -d= -f2 | tr ":" "\n"
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       register: discovered_root_paths_split
 
@@ -146,18 +154,22 @@
 
     - name: "5.4.2.5 | AUDIT | Ensure root path Integrity | Check for empty dirs"
       when: discovered_root_paths is defined
-      ansible.builtin.shell: 'echo {{ root_paths }} | grep -q "::" && echo "roots path contains a empty directory (::)"'
+      ansible.builtin.shell: |
+        set -o pipefail
+        echo {{ root_paths }} | grep -q "::" && echo "roots path contains a empty directory (::)"
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_root_path_empty_dir.rc not in [ 0, 1 ]
       register: discovered_root_path_empty_dir
 
     - name: "5.4.2.5 | AUDIT | Ensure root path Integrity | Check for trailing ':'"
       when: discovered_root_paths is defined
-      ansible.builtin.shell: 'echo {{ root_paths }} | cut -d= -f2 | grep -q ":$" && echo "roots path contains a trailing (:)"'
+      ansible.builtin.shell: |
+        set -o pipefail
+        echo {{ root_paths }} | cut -d= -f2 | grep -q ":$" && echo "roots path contains a trailing (:)"
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_root_path_trailing_colon.rc not in [ 0, 1 ]
       register: discovered_root_path_trailing_colon

--- a/tasks/section_6/cis_6.1.1.1.x.yml
+++ b/tasks/section_6/cis_6.1.1.1.x.yml
@@ -41,7 +41,11 @@
 
     - name: "6.1.1.1.2 | AUDIT | Ensure journald log file access is configured | If override file check for journal"
       when: discovered_tmpfile_override.stat.exists
-      ansible.builtin.shell: grep -E 'z /var/log/journal/%m/system.journal \d*' /usr/lib/tmpfiles.d/systemd.conf
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -E 'z /var/log/journal/%m/system.journal \d*' /usr/lib/tmpfiles.d/systemd.conf
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_journald_fileperms_override.rc not in [ 0, 1 ]
       register: discovered_journald_fileperms_override

--- a/tasks/section_6/cis_6.1.1.2.x.yml
+++ b/tasks/section_6/cis_6.1.1.2.x.yml
@@ -39,7 +39,7 @@
     - { regexp: 'ServerKeyFile=', line: 'ServerKeyFile={{ deb13cis_journal_upload_serverkeyfile }}'}
     - { regexp: 'ServerCertificateFile=', line: 'ServerCertificateFile={{ deb13cis_journal_servercertificatefile }}'}
     - { regexp: 'TrustedCertificateFile=', line: 'TrustedCertificateFile={{ deb13cis_journal_trustedcertificatefile }}'}
-  notify: Restart journald
+  notify: Restart systemd_journal_upload
 
 - name: "6.1.1.2.3 | PATCH | Ensure systemd-journal-upload is enabled and active"
   when:

--- a/tasks/section_6/cis_6.1.2.x.yml
+++ b/tasks/section_6/cis_6.1.2.x.yml
@@ -3,7 +3,7 @@
 - name: "6.1.2.1 | PATCH | Ensure rsyslog is installed"
   when:
     - deb13cis_rule_6_1_2_1
-    - "'rsyslog' not in ansible_facts.packages"
+    - "'rsyslog' not in ansible_facts['packages']"
   tags:
     - level1-server
     - level1-workstation
@@ -92,9 +92,11 @@
     warn_control_id: '6.1.2.5'
   block:
     - name: "6.1.2.5 | AUDIT | Ensure logging is configured | Find configuration file"
-      ansible.builtin.shell: grep -r "*.emerg" /etc/* | cut -f1 -d":"
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -r "*.emerg" /etc/* | cut -f1 -d":"
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       check_mode: false
@@ -203,7 +205,7 @@
 - name: "6.1.2.8 | PATCH | Ensure logrotate is configured"
   when:
     - deb13cis_rule_6_1_2_8
-    - "'logrotate' in ansible_facts.packages"
+    - "'logrotate' in ansible_facts['packages']"
   tags:
     - level1-server
     - level1-workstation

--- a/tasks/section_6/cis_6.3.x.yml
+++ b/tasks/section_6/cis_6.3.x.yml
@@ -13,8 +13,8 @@
   block:
     - name: "6.3.1 | PATCH | Ensure AIDE is installed"
       when:
-        - "'aide' not in ansible_facts.packages or
-          'aide-common' not in ansible_facts.packages"
+        - "'aide' not in ansible_facts['packages'] or
+          'aide-common' not in ansible_facts['packages']"
       ansible.builtin.package:
         name: ['aide', 'aide-common']
         state: present

--- a/tasks/section_7/cis_7.1.x.yml
+++ b/tasks/section_7/cis_7.1.x.yml
@@ -178,9 +178,11 @@
     - NIST800-53R5_MP-2
   block:
     - name: "7.1.11 | AUDIT | Ensure world writable files and directories are secured | Get list of world-writable files"
-      ansible.builtin.shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -0002
+      ansible.builtin.shell: |
+        set -o pipefail
+        df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -0002
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       failed_when: false
       changed_when: false
       register: discovered_worldwriteable_files
@@ -197,9 +199,11 @@
       loop: "{{ discovered_worldwriteable_files.stdout_lines }}"
 
     - name: "7.1.11 | PATCH | Ensure world writable files and directories are secured | Adjust world-writable directories add sticky bit"
-      ansible.builtin.shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d -perm -o+w ! -perm -1002 2>/dev/null | xargs chmod a+t
+      ansible.builtin.shell: |
+        set -o pipefail
+        df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d -perm -o+w ! -perm -1002 2>/dev/null | xargs chmod a+t
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       failed_when: discovered_set_stickybit.rc not in [ 0, 123 ]
       changed_when: discovered_set_stickybit.rc == 0
       register: discovered_set_stickybit
@@ -224,7 +228,7 @@
       check_mode: false
       register: discovered_unowned_files
       with_items:
-        - "{{ ansible_facts.mounts }}"
+        - "{{ ansible_facts['mounts'] }}"
       loop_control:
         label: "{{ item.mount }}"
 
@@ -278,13 +282,13 @@
     warn_control_id: '7.1.13'
   block:
     - name: "7.1.13 | AUDIT | Ensure SUID and SGID files are reviewed | Find SUID and SGID"
-      ansible.builtin.command: find {{ item.mount }} -xdev -type f -perm \( -02000 or -04000 \) -not -fstype nfs
+      ansible.builtin.command: find {{ item.mount }} -xdev -type f \( -perm -02000 -o -perm -04000 \) -not -fstype nfs
       changed_when: false
       failed_when: false
       check_mode: false
       register: discovered_suid_sgid_files
       with_items:
-        - "{{ ansible_facts.mounts }}"
+        - "{{ ansible_facts['mounts'] }}"
       loop_control:
         label: "{{ item.mount }}"
 

--- a/tasks/section_7/cis_7.2.x.yml
+++ b/tasks/section_7/cis_7.2.x.yml
@@ -13,7 +13,11 @@
     warn_control_id: '7.2.1'
   block:
     - name: "7.2.1 | AUDIT | Ensure accounts in /etc/passwd use shadowed passwords | Get users not using shadowed passwords"
-      ansible.builtin.shell: awk -F':' '($2 != "x" ) { print $1}' /etc/passwd
+      ansible.builtin.shell: |
+        set -o pipefail
+        awk -F':' '($2 != "x" ) { print $1}' /etc/passwd
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       register: discovered_nonshadowed_users
@@ -42,9 +46,11 @@
     - NIST800-53R5_IA-5
   block:
     - name: "7.2.2 | AUDIT | Ensure /etc/shadow password fields are not empty | Find users with no password"
-      ansible.builtin.shell: awk -F":" '($2 == "" ) { print $1 }' /etc/shadow
+      ansible.builtin.shell: |
+        set -o pipefail
+        awk -F":" '($2 == "" ) { print $1 }' /etc/shadow
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       check_mode: false
       no_log: true
@@ -75,9 +81,11 @@
     warn_control_id: '7.2.3'
   block:
     - name: "7.2.3 | AUDIT | Ensure all groups in /etc/passwd exist in /etc/group | Check /etc/passwd entries"
-      ansible.builtin.shell: pwck -r | grep 'no group' | awk '{ gsub("[:\47]",""); print $2}'
+      ansible.builtin.shell: |
+        set -o pipefail
+        pwck -r | grep 'no group' | awk '{ gsub("[:\47]",""); print $2}'
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       check_mode: false
@@ -112,12 +120,12 @@
         key: shadow
 
     - name: "7.2.4 | AUDIT | Ensure shadow group is empty | check users in group"
-      when: ansible_facts.getent_group.shadow[2] | length > 0
+      when: ansible_facts['getent_group']['shadow'][2] | length > 0
       ansible.builtin.debug:
         msg: "Warning!! - You have users in the shadow group"
 
     - name: "7.2.4 | AUDIT | Ensure shadow group is empty | check users in group"
-      when: ansible_facts.getent_group.shadow[2] | length > 0
+      when: ansible_facts['getent_group']['shadow'][2] | length > 0
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 
@@ -138,9 +146,11 @@
     warn_control_id: '7.2.5'
   block:
     - name: "7.2.5 | AUDIT | Ensure no duplicate UIDs exist | Check for duplicate UIDs"
-      ansible.builtin.shell: "pwck -r | awk -F: '{if ($3 in uid) print $1 ; else uid[$3]}' /etc/passwd"
+      ansible.builtin.shell: |
+        set -o pipefail
+        pwck -r | awk -F: '{if ($3 in uid) print $1 ; else uid[$3]}' /etc/passwd
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       check_mode: false
@@ -173,9 +183,11 @@
     warn_control_id: '7.2.6'
   block:
     - name: "7.2.6 | AUDIT | Ensure no duplicate GIDs exist | Check for duplicate GIDs"
-      ansible.builtin.shell: "pwck -r | awk -F: '{if ($3 in users) print $1 ; else users[$3]}' /etc/group"
+      ansible.builtin.shell: |
+        set -o pipefail
+        pwck -r | awk -F: '{if ($3 in users) print $1 ; else users[$3]}' /etc/group
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       check_mode: false
@@ -208,9 +220,11 @@
     warn_control_id: '7.2.7'
   block:
     - name: "7.2.7 | AUDIT | Ensure no duplicate user names exist | Check for duplicate User Names"
-      ansible.builtin.shell: "pwck -r | awk -F: '{if ($1 in users) print $1 ; else users[$1]}' /etc/passwd"
+      ansible.builtin.shell: |
+        set -o pipefail
+        pwck -r | awk -F: '{if ($1 in users) print $1 ; else users[$1]}' /etc/passwd
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       check_mode: false
@@ -219,7 +233,7 @@
     - name: "7.2.7 | WARNING | Ensure no duplicate user names exist | Print warning about users with duplicate User Names"
       when: discovered_username_check.stdout | length > 0
       ansible.builtin.debug:
-        msg: "Warning!! The following user names are duplicates: {{ discovered_user_username_check.stdout_lines }}"
+        msg: "Warning!! The following user names are duplicates: {{ discovered_username_check.stdout_lines }}"
 
     - name: "7.2.7 | WARNING | Ensure no duplicate user names exist | Set warning count"
       when: discovered_username_check.stdout | length > 0
@@ -243,9 +257,11 @@
     warn_control_id: '7.2.8'
   block:
     - name: "7.2.8 | AUDIT | Ensure no duplicate group names exist | Check for duplicate group names"
-      ansible.builtin.shell: 'getent group | cut -d: -f1 | sort -n | uniq -d'
+      ansible.builtin.shell: |
+        set -o pipefail
+        getent group | cut -d: -f1 | sort -n | uniq -d
       args:
-        executable: /bin/bash
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: false
       check_mode: false
@@ -328,7 +344,11 @@
     warn_control_id: '7.2.10'
   block:
     - name: "7.2.10 | AUDIT | Ensure local interactive user dot files access is configured"
-      ansible.builtin.shell: find {{ prelim_interactive_users_home.stdout_lines | list | join(' ') }} -name "\.*" -type f
+      ansible.builtin.shell: |
+        set -o pipefail
+        find {{ prelim_interactive_users_home.stdout_lines | list | join(' ') }} -name "\.*" -type f
+      args:
+        executable: "{{ deb13cis_shell_executable }}"
       changed_when: false
       failed_when: discovered_homedir_hidden_files.rc not in [ 0, 1 ]
       check_mode: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -34,6 +34,9 @@ container_vars_file: is_container.yml
 # system_is_ec2 toggle will disable tasks that fail on Amazon EC2 instances. Set true to skip and false to run tasks
 system_is_ec2: false
 
+# Shell used by shell tasks that require pipefail
+deb13cis_shell_executable: /bin/bash
+
 # Aide initiate command for new DB creation
 aide_initiate_command: aideinit -y -f
 


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
- sept26_update branch
  - 7.1.13 find used -perm \( ... or ... \); find read \( as the mode and never returned a
    file, so the SUID/SGID review passed vacuously. Now \( -perm -02000 -o -perm -04000 \)
  - 1.1.1.6 blacklisted overlayfs, which has not existed since the 3.x kernels. Now overlay,
    host-verified: modprobe -n -v overlay went from loading overlay.ko.xz to install /bin/true
  - 1.2.1.2 and 1.3.1.4 when: expressions were invalid Jinja (unquoted path, and not used as a
    binary operator) - both now quoted comparisons
  - prelim apt.conf.d find used patterns: .* as a glob, matching only dotfiles, so 1.2.1.2
    processed nothing. Added use_regex: true - host-verified 0 of 6 files matched before, 6 after
  - 3.2.1-3.2.6 modprobe tasks looped two lines against one fixed regexp, so the second item
    overwrote the first. Each item now carries its own regexp
  - 3.2.x install regexps were single-quoted, so \\s stayed literal and never matched
  - 3.1.2 wrote "install <mod> true" with a regexp naming "true"; now /bin/true and the module
  - 6.1.1.2.2 notified Restart journald, restarting the wrong service; now
    Restart systemd_journal_upload, which was previously unreachable
  - 7.2.7 warning referenced discovered_user_username_check, which is defined nowhere
  - removed a verbatim duplicate 3.2.3 dccp block
  - ansible_facts dot notation converted to bracket notation, 37 occurrences across 17 files
  - check_prereqs.yml when: reflowed to double quotes, the bracket form collides with a single-quoted scalar
  - deb13cis_shell_executable added to vars/main.yml, the role had no shell executable var
  - set -o pipefail and args executable applied to all 64 shell tasks
  - 4 folded '>' shell scalars in prelim.yml converted to literal '|', pipefail cannot work in a folded block
  - 34 hardcoded executable /bin/bash replaced with the role var
  - risky-shell-pipe removed from the .ansible-lint skip_list, the role now passes with it enabled
  - fixed the collection of audit privileged commands
  - 6.2.3.10 registered discovered_privileged_commands but the template reads discovered_privilege_processes, so no rules were written
  - Audit: 6.2.3.10 placeholder replaced with conf and running checks
 

**How has this been tested?:**
manually and subscribers
